### PR TITLE
Add immutable rootfs and grub docs

### DIFF
--- a/content/en/docs/Customizing/configure_grub.md
+++ b/content/en/docs/Customizing/configure_grub.md
@@ -4,13 +4,48 @@ linkTitle: "GRUB"
 weight: 4
 date: 2017-01-05
 description: >
-  GRUB 2 default boot entry setup
+  GRUB 2 Configuration
 ---
 
+COS is set to deploy a persistent `grub.cfg` into the `COS_RECOVERY` partition during
+the system installation or image creation. COS grub configuration
+includes three menu entries: first for the main OS system, second for the
+fallback OS system and a third for the recovery OS.
 
-Each bootable image have a default boot arguments which are defined in `/etc/cos/bootargs.cfg`. This file is used by GRUB to parse the cmdline used to boot the image. 
+For example the main OS system menu entry could be something like:
 
-For example:
+```
+menuentry "cOS" --id cos {
+  search.fs_label COS_STATE root
+  set img=/cOS/active.img
+  set label=COS_ACTIVE
+  loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd
+  initrd (loop0)$initramfs
+}
+```
+
+Someting relevant to note is that the kernel parameters are not part of the 
+persistent `grub.cfg` file stored in `COS_RECOVERY` partition. Kernel parameters
+are sourced from the loop device of the OS image to boot. This is mainly to
+keep kernel parameters consistent across different potential OS images or
+system upgrades. 
+
+In fact, cOS images and its derivatives, are expected to include a
+`/etc/cos/bootargs.cfg` file which provides the definition of the following
+variables:
+
+* `$kernel`: Path of the kernel binary 
+* `$kernelcmd`: Kernel parameters
+* `$initramfs`: Path of the initrd binary
+
+This is the mechanism any cOS image or cOS derivative has to communicate
+its boot parameters (kernel, kernel params and initrd file) to GRUB2.
+
+For example a cOS bootarg.cfg file could be:
+
 ```
 set kernel=/boot/vmlinuz
 if [ -n "$recoverylabel" ]; then
@@ -27,8 +62,9 @@ set initramfs=/boot/initrd
 You can tweak that file to suit your needs if you need to specify persistent boot arguments.
 
 ## Grub environment variables
-cOS (since v0.5.8) makes use of the grub2 environment block which can used to define
-persistent grub2 variables across reboots.
+
+cOS (since v0.5.8) makes use of the GRUB2 environment block which can used to define
+persistent GRUB2 variables across reboots.
 
 The default grub configuration loads the `/grubenv` of any available device
 and evaluates on `next_entry` variable and `saved_entry` variable. By default
@@ -38,7 +74,7 @@ The default boot entry is set to the value of `saved_entry`, in case the variabl
 is not set grub just defaults to the first menu entry.
 
 `next_entry` variable can be used to overwrite the default boot entry for a single
-boot. If `next_entry` variable is set this is only being used once, grub2 will
+boot. If `next_entry` variable is set this is only being used once, GRUB2 will
 unset it after reading it for the first time. This is helpful to define the menu entry
 to reboot to without having to make any permanent config change.
 
@@ -57,5 +93,5 @@ Or to set the default entry to `fallback` system:
 ```
 
 These examples make of the `COS_OEM` device, however it could use any device
-detected by grub2 that includes the file `/grubenv`. First match wins.
+detected by GRUB2 that includes the file `/grubenv`. First match wins.
 

--- a/content/en/docs/Customizing/stages.md
+++ b/content/en/docs/Customizing/stages.md
@@ -12,9 +12,28 @@ Cloud-init files in `/system/oem`, `/oem` and `/usr/local/oem` are applied in 5 
 
 Multiple stages can be specified in a single cloud-init file.
 
+#### rootfs
+
+This is the earliest stage, running before switching root, just right after the
+root is mounted in `/sysroot` and before applying the immutable rootfs configuration.
+This stage is executed over initrd root, no chroot is applied.
+
+Example:
+```yaml
+name: "Set persistent devices"
+stage:
+  rootfs:
+    - name: "Layout configuration"
+      environment_file: /run/cos/cos-layout.env
+      environment:
+        VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"
+        OVERLAY: "tmpfs:25%"
+```
+
 #### initramfs
 
-This is the earliest stage, running before switching root. Here you can apply radical changes to the booting setup of `cOS`.
+This is still an early stage, running before switching root. Here you can apply radical changes to the booting setup of `cOS`.
+Despite this is executed before switching root this exection runs chrooted into the target root after the immutable rootfs is set up and ready.
 
 Example:
 ```yaml
@@ -26,7 +45,7 @@ stages:
        commands:
        - |
           # Run something when we are booting in active or passive
-          touch /sysroot/etc/something_important
+          touch /etc/something_important
      - name: "Setting"
        if: '[ -f "/run/cos/recovery_mode" ]'
        commands:

--- a/content/en/docs/Getting started/booting.md
+++ b/content/en/docs/Getting started/booting.md
@@ -56,7 +56,7 @@ At the moment we support Azure and AWS images among our artifacts. We publish al
 
 1. Upload the raw image to an S3 bucket
 ```
-aws s3 cp <cos-raw-image> s3://cos-images
+aws s3 cp <cos-raw-image> s3://<your_s3_bucket>
 ```
 
 2. Created the disk container JSON (`container.json` file) as:
@@ -66,7 +66,7 @@ aws s3 cp <cos-raw-image> s3://cos-images
   "Description": "cOS Testing image in RAW format",
   "Format": "raw",
   "UserBucket": {
-    "S3Bucket": "cos-images",
+    "S3Bucket": "<your_s3_bucket>",
     "S3Key": "<cos-raw-image>"
   }
 }
@@ -104,12 +104,13 @@ stages:
              # filesystem: ext4
              pLabel: persistent
    network:
-     - if: '[ -z "$(blkid -L COS_SYSTEM || true)" ]'
+     - if: '[ -f "/run/cos/recovery_mode" ]'
        name: "Deploy cos-system"
        commands:                                                                 
          - |
-             cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.3-3 && \
-             shutdown -r +1
+             # Use `cos-deploy --docker-image <img-ref>` to deploy a custom image
+             # By default latest cOS gets deployed
+             cos-deploy && shutdown -r +1
 
 ```
 

--- a/content/en/docs/Reference/immutable_rootfs.md
+++ b/content/en/docs/Reference/immutable_rootfs.md
@@ -1,0 +1,119 @@
+---
+title: "Immutable Root Filesystem"
+linkTitle: "Immutable Rootfs"
+weight: 4
+date: 2017-01-05
+description: >
+  Immutable root filesystem configuration parameters
+---
+
+The immutable rootfs concept in cOS is provided by a dracut module which is
+basically the contents of the `immutable-rootfs` luet package provided as part
+of the cOS repository tree.
+
+The dracut module is mostly configured via kernel command line parameters or
+via the `/run/cos/cos-layout.env` environment file.
+
+The immutable rootfs module is the responsible of mounting the root tree at 
+boot time with the immutable specific setup. The immutability concept refers
+to read only root (`/`) system. To ensure the linux OS is still functional
+certain paths or areas are required to be writable, in those cases an
+ephemeral overaly tmpfs is set in place. Additionaly, the immutable rootfs
+module can also mount a custom list of device blocks with read write
+permissions, those are mostly devoted to store persistent data.
+
+These are the read write paths the module mounts as part of the overlay
+ephemeral tmpfs: `/etc`, `/root`, `/home`, `/opt`, `/srv`, `/usr/local`
+and `/var`.
+
+These paths will be all ephemeral unless there is a block device configured
+to be mounted in the same path.
+
+It is important to remark all the immutable root configuration is applied
+in initrd before switching root and after `rootfs` cloud-init stage but
+before `initramfs` stage. So immutable rootfs configuration via cloud-init
+using the `/run/cos/cos-layout.env` file is only effective if called in any
+of the `rootfs.before`, `rootfs` or `rootfs.after` cloud-init stages.
+
+## Kernel configuraton paramters
+
+The immutable rootfs can be configured witht he following kernel parameters:
+
+* `cos-img/filename=<imgfile>`: This is one of the main parameters, it defines
+  the location of the image file to boot from.
+
+* `rd.cos.overlay=tmpfs:<size>`: This defines the size of the tmpfs used for
+  the ephemeral overlayfs. It can be expressed in MiB or as a % of the available
+  memory. Defaults to `rd.cos.overlay=tmpfs:20%` if not present.
+
+* `rd.cos.overlay=LABEL=<vol_label>`: Optionally and mostly for debugging
+  purposes the overlayfs can be mounted on top of a persistent block device.
+  Block devices can be expressed by LABEL (`LABEL=<blk_label>`) or by UUID
+  (`UUID=<blk_uuid>`)
+
+* `rd.cos.mount=LABEL:<blk_label>:<mountpoint>`: This option defines a
+  persistent block device and its mountpoint. Block devices can also be
+  defined by UUID (`UUID=<blk_uuid>:<mountpoint>`). This option can be passed
+  multiple times.
+
+* `rd.cos.oemtimeout=<seconds>`: cOS by default assumes the existence of a
+  persistent block device labelled `COS_OEM` which is used to keep some
+  configuration data (mostly cloud-init files). The immutable rootfs tries
+  to mount this device at very early stages of the boot even before applying
+  the immutable rootfs configs. It done this way to enable to configure the
+  immutable rootfs module within the cloud-init files. As the `COS_OEM` device
+  might not be always present the boot process just continues without failing
+  after a certain timeout. This option configures such a timeout. Defaults to
+  10s.
+
+* `rd.cos.debugrw`: This is a boolean option, true if present, false if not.
+  This option sets the root image to be mounted as a writable device. Note this
+  completely breaks the concept of an immutable root. This is helpful for
+  debugging or testing purposes, so changes persist across reboots.
+
+* `rd.cos.disable`: This is a boolean option, true if present, false if not.
+  It disables the execution of any immutable rootfs module logic at boot.
+
+### Configuration with an environment file
+
+The immutable rootfs can be configured with the `/run/cos/cos-layout.env`
+environment file. It is important to note that all the immutable root
+configuration is applied in initrd before switching root and after
+`rootfs` cloud-init stage but before `initramfs` stage. So immutable rootfs
+configuration via cloud-init using the `/run/cos/cos-layout.env` file is
+only effective if called in any of the `rootfs.before`, `rootfs` or
+`rootfs.after` cloud-init stages.
+
+
+In the environment file only few options are available:
+
+
+* `VOLUMES=LABEL=<blk_label>:<mountpoint>`: This variable expects a block device
+  and it mountpoint pair space separated list. The default cOS configuration is:
+
+  `VOLUMES="LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"`
+  
+* `OVERLAY=`: It defines the underlaying device for the overlayfs as in
+  `rd.cos.overlay=` kernel parameter.
+
+* `DEBUGRW=true`: Sets the root (`/`) to be mounted with read/write permissions.
+
+* `MERGE=true`: Sets makes the `VOLUMES` values to be merged with any other
+  volume that might have been defined in the kernel command line. The merging
+  criteria is simple: any overlapping volume is overwritten all others are
+  appended to whatever was already defined as a kernel parameter. If not
+  defined defaults to `true`.
+
+For exmaple a common cOS configuration can is expressed as part of the
+cloud-init configuration as follows:
+
+```yaml
+name: example
+stage:
+  rootfs:
+    - name: "Layout configuration"
+      environment_file: /run/cos/cos-layout.env
+      environment:
+        VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"
+        OVERLAY: "tmpfs:25%"
+```


### PR DESCRIPTION
This commit adds some reference documentationf or the immutable rootfs
dracut module and in addition adds few details about the GRUB2
configuration.

Fixes rancher-sandbox/cOS-toolkit#237

Signed-off-by: David Cassany <david@localhost.localdomain>