### PR TITLE
Document cloud-config as optional and link to package browser by adding shortcode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -69,6 +69,12 @@ weight = 1
     url = "https://github.com/rancher-sandbox/cOS-toolkit/releases"
     pre = "<i class='fab fa-github'></i>"
     post = "" 
+[[menu.main]]
+    name = "Browse packages"
+    weight = 55
+    url = "https://cos-toolkit.herokuapp.com/cos-toolkit-green"
+    pre = "<i class='fa fa-toolbox'></i>"
+    post = "" 
 
 [markup]
   [markup.goldmark]

--- a/content/en/docs/Creating derivatives/creating_bootable_images.md
+++ b/content/en/docs/Creating derivatives/creating_bootable_images.md
@@ -36,6 +36,8 @@ RUN luet install -y meta/cos-minimal
 
 In the example above, the cos-toolkit parts that are **required** are pulled in by `RUN luet install -y meta/cos-minimal`.
 
+{{<package package="meta/cos-minimal" >}} is a meta-package that will pull {{<package package="toolchain/yip" >}}, {{<package package="utils/installer" >}}, {{<package package="system/cos-setup" >}}, {{<package package="system/immutable-rootfs" >}}, {{<package package="system/grub2-config" >}}, {{<package package="system/cloud-config" >}}. _Note_: {{<package package="system/cloud-config" >}} is optional, but provides `cOS` defaults setting, like default user/password and so on. If you are not installing it directly, an equivalent cloud-config has to be provided in order to properly boot and run a system, see [oem configuration](../../customizing/oem_configuration).
+
 {{% alert title="Note" %}}
 The image should provide at least `grub`, `systemd`, `dracut`, a kernel and an initrd. Those are the common set of packages between derivatives. See also [package stack](../package_stack). 
 By default the initrd is expected to be symlinked to `/boot/initrd` and the kernel to `/boot/vmlinuz`, otherwise you can specify a custom path while [building an iso](../build_iso) and [by customizing grub](../../customizing/configure_grub).

--- a/content/en/docs/Customizing/oem_configuration.md
+++ b/content/en/docs/Customizing/oem_configuration.md
@@ -16,25 +16,26 @@ For runtime persistence configuration, the only supported way is with cloud-conf
 
 A derivative automatically loads and executes cloud-config files during the various system [stages](../stages) also inside `/system/oem` which is read-only and reserved to the system.
 
-{{% pageinfo %}}
+{{% alert title="Note" %}}
 The cloud-config mechanism works also as an emitter event pattern - running services or programs can emit new custom `stages` in runtime by running `cos-setup stage_name`.
-{{% /pageinfo %}}
+{{% /alert %}}
 
 Derivatives that wish to override default configurations can do that by placing extra cloud-init file, or overriding completely `/system/oem` in the target image.
 
 This is to setup for example, the default root password or the prefered upgrade channel. 
 
-The following are the `cOS` default oem files:
+The following are the `cOS` default oem files, which are shipped within the {{<package package="system/cloud-config" >}}, which is an optional package:
+
 ```
 /system/oem/00_rootfs.yaml - defines the rootfs mountpoint layout setting
 /system/oem/01_defaults.yaml - systemd defaults (keyboard layout, timezone)
-/system/oem/02_upgrades.yaml - Settings for channel upgrades
+/system/oem/02_upgrades.yaml - Settings for cOS vanilla channel upgrades
 /system/oem/03_branding.yaml - Branding setting, Derivative name, /etc/issue content
 /system/oem/04_accounting.yaml - Default user/pass
 /system/oem/05_network.yaml - Default network setup
 /system/oem/06_recovery.yaml - Executes additional commands when booting in recovery mode
 ```
 
-If you are building a cOS derivative, and plan to release upgrades, you must override (or create a new file under `/system/oem`) the `/system/oem/02_upgrades.yaml` pointing to the docker registry used to deliver upgrades.
+You can either override the above files, or alternatively not consume the {{<package package="system/cloud-config" >}} package while building a derivative.
 
 [See also the example appliance](https://github.com/rancher-sandbox/epinio-appliance-demo-sample#images)

--- a/content/en/docs/Customizing/runtime_features.md
+++ b/content/en/docs/Customizing/runtime_features.md
@@ -32,7 +32,7 @@ To disable, run: cos-feature disable <feature>
 
 By default cOS ships the `vagrant` featureset - when enabled will automatically create the default `vagrant` user which is generally used to create new Vagrant boxes. 
 
-If you don't need `cos-features` you can avoid installing `system/cos-features`, it's optional.
+If you don't need `cos-features` you can avoid installing {{<package package="system/cos-features" >}}, it's optional.
 
 ## Adding or removing features
 

--- a/content/en/docs/Examples/creating_bootable_images.md
+++ b/content/en/docs/Examples/creating_bootable_images.md
@@ -36,8 +36,7 @@ toolchain/yip
 utils/installer
 system/cos-setup
 system/immutable-rootfs
-system/grub-config
-system/cloud-config
+system/grub2-config
 ```
 
 from the toolchain. If you want to customize further the container further add more step afterwards `luet install` see [the customizing section](../../customizing).

--- a/layouts/shortcodes/package.html
+++ b/layouts/shortcodes/package.html
@@ -1,0 +1,9 @@
+{{ $package := (.Get "package") }}
+{{ $website := ( or (.Get "website") "https://cos-toolkit.herokuapp.com/cos-toolkit-green" ) }}
+<a href="{{ print $website "/" $package }}" class="btn btn-sm position-relative rounded-pill bg-light text-dark"
+    role="button">
+    {{$package}}
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-light">
+        <i class='fa fa-box'></i>
+    </span>
+</a>

--- a/layouts/shortcodes/package.html
+++ b/layouts/shortcodes/package.html
@@ -2,8 +2,5 @@
 {{ $website := ( or (.Get "website") "https://cos-toolkit.herokuapp.com/cos-toolkit-green" ) }}
 <a href="{{ print $website "/" $package }}" class="btn btn-sm position-relative rounded-pill bg-light text-dark"
     role="button">
-    {{$package}}
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-light">
-        <i class='fa fa-box'></i>
-    </span>
+    <i class='fa fa-box'></i> {{$package}}
 </a>


### PR DESCRIPTION
Fixes: https://github.com/rancher-sandbox/cOS-toolkit/issues/571

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>