### PR TITLE
Generate docs from specfiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,7 @@ jobs:
         run: |
           npm install postcss-cli
           npm install autoprefixer
+          curl https://raw.githubusercontent.com/rancher-sandbox/cOS-toolkit/master/scripts/get_luet.sh | sudo bash -
+          sudo luet install -y toolchain/yq
       - name: Build pages
-        run: make build
+        run: make generate-docs build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+   - cron: 0 20 * * *
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
         run: |
               npm install postcss-cli
               npm install autoprefixer
+              curl https://raw.githubusercontent.com/rancher-sandbox/cOS-toolkit/master/scripts/get_luet.sh | sudo bash -
+              sudo luet install -y toolchain/yq
+      - name: Build package docs
+        run: make generate-docs
       - name: Publish Site
         uses: chabad360/hugo-gh-pages@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ resources/
 node_modules/
 tech-doc-hugo
 bin/
+cos/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 export HUGO_VERSION?=0.85.0
 export HUGO_PLATFORM?=Linux-64bit
+export COS_REPO?=https://github.com/rancher-sandbox/cOS-toolkit
 
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
@@ -16,3 +17,9 @@ serve:
 .PHONY: publish
 publish:
 	scripts/publish.sh
+
+cos:
+	git clone $(COS_REPO) cos
+
+generate-docs: cos
+	scripts/generate_packages_docs.sh cos/packages

--- a/content/en/docs/Customizing/_index.md
+++ b/content/en/docs/Customizing/_index.md
@@ -7,20 +7,3 @@ date: 2017-01-05
 description: >
   This section contains various articles relative on how to customize cOS, branding and behavior.
 ---
-
-![Partitioning layout](https://docs.google.com/drawings/d/e/2PACX-1vR-I5ZwwB5EjpsymUfcNADRTTKXrNMnlZHgD8RjDpzYhyYiz_JrWJwvpcfMcwfYet1oWCZVWH22aj1k/pub?w=533&h=443)
-
-By default, `cos` and derivatives will inherit an immutable setup.
-A running system will look like as follows:
-
-```
-/usr/local - persistent (COS_PERSISTENT)
-/oem - persistent (COS_OEM)
-/etc - ephemeral
-/usr - read only
-/ immutable
-```
-
-This means that any changes that are not specified as cloud-init configuration are not persisting across reboots.
-
-You can place persisting cloud-init files either in `/oem` or `/usr/local/oem`, `cOS` already supports cloud-init [datasources](https://cloudinit.readthedocs.io/en/latest/topics/datasources.html), so you can use also load cloud-init configuration as standard userdata, depending on the platform. For more details on the cloud-init syntax, see the [cloud-init configuration reference](../reference/cloud_init).

--- a/content/en/docs/Reference/Packages/_index.md
+++ b/content/en/docs/Reference/Packages/_index.md
@@ -1,0 +1,15 @@
+
+---
+title: "Package reference documentation"
+linkTitle: "Packages"
+weight: 4
+date: 2017-01-05
+description: >
+  This section contains documentation for core packages present in the cOS toolkit repositories
+---
+
+There are a set of core packages available in the cOS repositories which are installable with `luet` while creating a derivative in the Dockerfile. Those bring in new features, enhancements and core features of the cOS toolkit. Some are optional (like runtime features) while some of them are strictly necessary in order for a cOS system to boot and operate correctly. 
+
+This section contains reference documentation specific to core packages in the cOS repositories and the functionalities they bring.
+
+All the packages available can also be browsed [here](https://rancher-sandbox.github.io/cos-toolkit-package-browser/).

--- a/content/en/docs/Reference/immutable_rootfs.md
+++ b/content/en/docs/Reference/immutable_rootfs.md
@@ -8,145 +8,27 @@ description: >
 ---
 
 The immutable rootfs concept in cOS is provided by a dracut module which is
-basically the contents of the `immutable-rootfs` luet package provided as part
+basically the contents of the [immutable-rootfs](../../reference/packages/system-immutable-rootfs) package provided as part
 of the cOS repository tree.
 
-The dracut module is mostly configured via kernel command line parameters or
-via the `/run/cos/cos-layout.env` environment file.
+By default, `cos` and derivatives will inherit an immutable setup.
 
-The immutable rootfs module is responsible of mounting the root tree during 
-boot time with the immutable specific setup. The immutability concept refers
-to read only root (`/`) system. To ensure the linux OS is still functional
-certain paths or areas are required to be writable, in those cases an
-ephemeral overaly tmpfs is set in place. Additionaly, the immutable rootfs
-module can also mount a custom list of device blocks with read write
-permissions, those are mostly devoted to store persistent data.
+![Partitioning layout](https://docs.google.com/drawings/d/e/2PACX-1vR-I5ZwwB5EjpsymUfcNADRTTKXrNMnlZHgD8RjDpzYhyYiz_JrWJwvpcfMcwfYet1oWCZVWH22aj1k/pub?w=533&h=443)
 
-These are the read write paths the module mounts as part of the overlay
-ephemeral tmpfs: `/etc`, `/root`, `/home`, `/opt`, `/srv`, `/usr/local`
-and `/var`.
+A running system will look like as follows:
 
-These paths will be all ephemeral unless there is a block device configured
-to be mounted in the same path.
-
-It is important to remark all the immutable root configuration is applied
-in initrd before switching root and after `rootfs` cloud-init stage but
-before `initramfs` stage. So immutable rootfs configuration via cloud-init
-using the `/run/cos/cos-layout.env` file is only effective if called in any
-of the `rootfs.before`, `rootfs` or `rootfs.after` cloud-init stages.
-
-## Kernel configuraton paramters
-
-The immutable rootfs can be configured witht he following kernel parameters:
-
-* `cos-img/filename=<imgfile>`: This is one of the main parameters, it defines
-  the location of the image file to boot from.
-
-* `rd.cos.overlay=tmpfs:<size>`: This defines the size of the tmpfs used for
-  the ephemeral overlayfs. It can be expressed in MiB or as a % of the available
-  memory. Defaults to `rd.cos.overlay=tmpfs:20%` if not present.
-
-* `rd.cos.overlay=LABEL=<vol_label>`: Optionally and mostly for debugging
-  purposes the overlayfs can be mounted on top of a persistent block device.
-  Block devices can be expressed by LABEL (`LABEL=<blk_label>`) or by UUID
-  (`UUID=<blk_uuid>`)
-
-* `rd.cos.mount=LABEL:<blk_label>:<mountpoint>`: This option defines a
-  persistent block device and its mountpoint. Block devices can also be
-  defined by UUID (`UUID=<blk_uuid>:<mountpoint>`). This option can be passed
-  multiple times.
-
-* `rd.cos.oemtimeout=<seconds>`: cOS by default assumes the existence of a
-  persistent block device labelled `COS_OEM` which is used to keep some
-  configuration data (mostly cloud-init files). The immutable rootfs tries
-  to mount this device at very early stages of the boot even before applying
-  the immutable rootfs configs. It done this way to enable to configure the
-  immutable rootfs module within the cloud-init files. As the `COS_OEM` device
-  might not be always present the boot process just continues without failing
-  after a certain timeout. This option configures such a timeout. Defaults to
-  10s.
-
-* `rd.cos.debugrw`: This is a boolean option, true if present, false if not.
-  This option sets the root image to be mounted as a writable device. Note this
-  completely breaks the concept of an immutable root. This is helpful for
-  debugging or testing purposes, so changes persist across reboots.
-
-* `rd.cos.disable`: This is a boolean option, true if present, false if not.
-  It disables the execution of any immutable rootfs module logic at boot.
-
-### Configuration with an environment file
-
-The immutable rootfs can be configured with the `/run/cos/cos-layout.env`
-environment file. It is important to note that all the immutable root
-configuration is applied in initrd before switching root and after
-`rootfs` cloud-init stage but before `initramfs` stage. So immutable rootfs
-configuration via cloud-init using the `/run/cos/cos-layout.env` file is
-only effective if called in any of the `rootfs.before`, `rootfs` or
-`rootfs.after` cloud-init stages.
-
-
-In the environment file few options are available:
-
-
-* `VOLUMES=LABEL=<blk_label>:<mountpoint>`: This variable expects a block device
-  and it mountpoint pair space separated list. The default cOS configuration is:
-
-  `VOLUMES="LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"`
-  
-* `OVERLAY`: It defines the underlaying device for the overlayfs as in
-  `rd.cos.overlay=` kernel parameter.
-
-* `DEBUGRW=true`: Sets the root (`/`) to be mounted with read/write permissions.
-
-* `MERGE=true`: Sets makes the `VOLUMES` values to be merged with any other
-  volume that might have been defined in the kernel command line. The merging
-  criteria is simple: any overlapping volume is overwritten all others are
-  appended to whatever was already defined as a kernel parameter. If not
-  defined defaults to `true`.
-
-* `RW_PATHS`: This is a space separated list of paths. These are the paths
-  that will be used for the ephemeral overlayfs. These are the paths that
-  will be mounted as overlay on top of the `OVERLAY` (or `rd.cos.overlay`)
-  device. Default value is:
-
-  `RW_PATHS="/etc /root /home /opt /srv /usr/local /var"`
-  **Note**: as those paths are overlayed with an ephemeral mount (`tmpfs`), 
-            additional data wrote on those location won't be available on subsequent boots.
-
-* `PERSISTENT_STATE_TARGET`: This is the folder where the persistent state data
-  will be stored, if any. Default value is `/usr/local/.state`.
-
-* `PERSISTENT_STATE_PATHS`: This is a space separated list of paths. These are
-  the paths that will become writable and store its data inside
-  `PERSISTENT_STATE_TARGET`. By default this variable is empty, which means
-  no persistent state area is created or used.
-
-  **Note**: The specified paths needs either to exist or be located in an area 
-            which is writeable ( for example, inside locations specified with `RW_PATHS`).
-            The dracut module will attempt to create non-existant directories, 
-            but might fail if the mountpoint where are located is read-only.
-
-* `PERSISTENT_STATE_BIND="true|false"`: When this variable is set to true
-  the persistent state paths are bind mounted (instead of using overlayfs)
-  after being mirrored with the original content. By default this variable is
-  set to `false`.
-
-Note that persistent state are is setup once the ephemeral paths and persistent
-volumes are mounted. Persistent state paths can't be an already existing mount
-point. If the persistent state requires any of the paths that are part of the
-ephemeral area by default, then `RW_PATHS` needs to be defined to avoid
-overlapping paths.
-
-For exmaple a common cOS configuration can be expressed as part of the
-cloud-init configuration as follows:
-
-```yaml
-name: example
-stage:
-  rootfs:
-    - name: "Layout configuration"
-      environment_file: /run/cos/cos-layout.env
-      environment:
-        VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"
-        OVERLAY: "tmpfs:25%"
 ```
+/usr/local - persistent (COS_PERSISTENT)
+/oem - persistent (COS_OEM)
+/etc - ephemeral
+/usr - read only
+/ immutable
+```
+
+This means that any changes that are not specified as cloud-init configuration are not persisting across reboots.
+
+You can place persisting cloud-init files either in `/oem` or `/usr/local/oem`, `cOS` already supports cloud-init [datasources](https://cloudinit.readthedocs.io/en/latest/topics/datasources.html), so you can use also load cloud-init configuration as standard userdata, depending on the platform. For more details on the cloud-init syntax, see the [cloud-init configuration reference](../reference/cloud_init).
+
+{{% alert title="Note" %}}
+You can check the package [documentation reference](../../reference/packages/system-immutable-rootfs) for a detailed explaination of the configuration and how to override default settings. Immutability, as of other aspects, can be disabled.
+{{% /alert %}}

--- a/scripts/generate_packages_docs.sh
+++ b/scripts/generate_packages_docs.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -e
+# This scripts read package specs with a 'documentation' field and generates the corresponding pages in the website
+
+TREE_DIR=$1
+if [ -z "$TREE_DIR" ]; then 
+    echo "Need to specify a package tree directory"
+    exit 1
+fi
+
+GENERATED_DOCS=${2:-content/en/docs/Reference/Packages}
+
+echo "Generating docs at $GENERATED_DOCS"
+
+PKG_LIST=$(luet tree pkglist --tree $TREE_DIR -o json)
+
+header() {
+    local pn=$1
+    local pc=$2
+    local pv=$3
+    cat <<EOF
+---
+title: "$pc/$pn"
+linkTitle: "$pn"
+date: $(date '+%Y-%m-%d')
+description: >
+  Documentation for the $pc/$pn package
+---
+
+{{% alert title="Note" %}}
+{{<package package="$pc/$pn" >}} is part of the cOS toolkit repository and can be installed with:
+
+\`\`\`bash
+luet install -y $pc/$pn
+\`\`\`
+
+in the derivative's Dockerfile.
+{{% /alert %}}
+
+EOF
+}
+
+write_package() {
+    local package_path=$1
+    local package_name=$2
+    local package_category=$3
+    local package_version=$4
+    local readme_file=$5
+    local subdir=$6
+    if [ -z "$readme_file" ]; then
+        readme_file="README-$package_category-$package_name.md"
+    fi
+    if [ -e "$package_path/$readme_file" ]; then
+      echo "$(header $package_name $package_category $package_version)" > $GENERATED_DOCS/$subdir/$package_category-$package_name.md
+      cat "$package_path/$readme_file" >> $GENERATED_DOCS/$subdir/$package_category-$package_name.md
+      echo "Generated $GENERATED_DOCS/$subdir/$package_category-$package_name.md"
+    fi
+}
+
+if [ ! -d $GENERATED_DOCS ]; then
+    mkdir -p $GENERATED_DOCS
+fi
+
+for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
+    PACKAGE_PATH=$(echo "$i" | jq -r ".path")
+    PACKAGE_NAME=$(echo "$i" | jq -r ".name")
+    PACKAGE_CATEGORY=$(echo "$i" | jq -r ".category")
+    PACKAGE_VERSION=$(echo "$i" | jq -r ".version")
+
+    # We read README.md and README-cat-name.md files.
+    # When a collection is found, we generate an _index.md with README.md and README-head.md content if they exists, while
+    # collection packages specific documentation can be supplied with files like `README-cat-name.md`
+    if [ -e "$PACKAGE_PATH/collection.yaml" ]; then
+       if [ -e "$PACKAGE_PATH/README.md" ] && [ -e "$PACKAGE_PATH/README-head.md" ]; then
+        # Unique folder for each collection
+        dir=$(yq e '.linkTitle' $PACKAGE_PATH/README-head.md | head -n1)
+        dir="${dir/ /-}"
+        if [ ! -d $GENERATED_DOCS/$dir ]; then
+            mkdir -p $GENERATED_DOCS/$dir
+            cat "$PACKAGE_PATH/README-head.md" > $GENERATED_DOCS/$dir/_index.md
+            cat "$PACKAGE_PATH/README.md" >> $GENERATED_DOCS/$dir/_index.md
+            echo "Generated $GENERATED_DOCS/$dir/_index.md"
+        fi
+        write_package $PACKAGE_PATH $PACKAGE_NAME $PACKAGE_CATEGORY $PACKAGE_VERSION "" "$dir"
+       else
+        write_package $PACKAGE_PATH $PACKAGE_NAME $PACKAGE_CATEGORY $PACKAGE_VERSION "" ""
+       fi
+    else
+        # Packages which are not a collection are easier, the README.md is 
+        # directly used for generating the page
+        write_package $PACKAGE_PATH $PACKAGE_NAME $PACKAGE_CATEGORY $PACKAGE_VERSION "README.md" ""
+    fi
+done


### PR DESCRIPTION
Needs: https://github.com/rancher-sandbox/cOS-toolkit/pull/907
Part of: https://github.com/rancher-sandbox/cOS-toolkit/issues/757

This PR introduce a script which generates layout/structure to be parsed from our docs to be displayed in the website. It parses the cos-toolkit repository packages and scans for `README.md` files present in the package path (where `build.yaml` and `definition.yaml` reside).

If it's a collection, it still reads for README files, but allows also to generate per-package documentation by checking the presence of `README-cat-name.md` in the package path, if present it will create a new grouped page and put the packages of the collection under it.

In order to preserve readability on cos-toolkit side, the page header of a collection cannot be generated cleanly, so a `README-head.md` file is required with the specific docsy fields, e.g: 
```yaml
---
title: "Collection name"
linkTitle: "Collection title"
date: 2021-12-02
description: >
  Collection description
---
```

WIP as I'm currently moving other docs over the repo, so we have more contextual docs 