### PR TITLE
fixup: require bash here

### DIFF
--- a/scripts/generate_packages_docs.sh
+++ b/scripts/generate_packages_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 # This scripts read package specs with a 'documentation' field and generates the corresponding pages in the website
 


### PR DESCRIPTION
Fixes:

```
Run make generate-docs
git clone https://github.com/rancher-sandbox/cOS-toolkit cos
Cloning into 'cos'...
scripts/generate_packages_docs.sh cos/packages
Generating docs at content/en/docs/Reference/Packages
scripts/generate_packages_docs.sh: 77: Bad substitution
make: *** [Makefile:25: generate-docs] Error 2
Error: Process completed with exit code 2.
```
See: https://github.com/rancher-sandbox/cos-toolkit-docs/runs/4423924002?check_suite_focus=true
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>